### PR TITLE
Fix collission attacks on secured strings generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,17 @@ python-ulid==1.1.0
 redis==4.6.0
 redis-om==0.2.1
 requests==2.31.0
+shortuuid==1.0.11
 snowballstemmer==2.2.0
+Sphinx==7.2.6
+sphinx-rtd-theme==1.3.0
+sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-htmlhelp==2.0.4
+sphinxcontrib-jquery==4.1
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-serializinghtml==1.1.9
 tomli==2.0.1
 types-pyOpenSSL==23.2.0.2
 types-redis==4.6.0.7

--- a/src/user_db_manager.py
+++ b/src/user_db_manager.py
@@ -14,6 +14,7 @@ from typing import (
 )
 from logging.handlers import RotatingFileHandler
 import argon2
+import shortuuid
 from argon2 import PasswordHasher
 from dotenv import load_dotenv
 
@@ -174,6 +175,15 @@ class UserDBManager:
         hashed_user_string = passwd_hash.hash(user_string_bytes)
         return hashed_user_string
 
+    def generate_secured_string(self) -> str:
+        """Method to generate secured user string 
+        using the global uuid and shortuuid module
+        """
+        unique_id = uuid.uuid4()
+        secure_user_string = shortuuid.encode(unique_id)
+        return secure_user_string
+
+
     def store_user_string(
             self,
             req: Dict[str, str]) \
@@ -202,10 +212,8 @@ class UserDBManager:
             )
 
             if hash_string is not None:
-                secure_user_string = base64.urlsafe_b64encode(
-                    hash_string
-                ).decode('utf-8')
-                individual_store['secured_user_string'] = secure_user_string
+                secured_user_string = self.generate_secured_string().encode('utf-8')
+                individual_store['secured_user_string'] = secured_user_string
                 individual_store['_id'] = self.__unique_identifier.encode(
                     'utf-8')
                 individual_store['created_on'] = str(


### PR DESCRIPTION
Valid concern in relation to the secured string generation using b64 on the hash string in the dbm. As b64 could be decoded and also hashing with cryptic tech like argon on equal inputs produces same hashing. This is a critical security concern needed to be addressed. Hence opting to use uuid and encoding it with shortuuid for the `sus`. 